### PR TITLE
udpipe script

### DIFF
--- a/src/metadater/tei_parczech.xml
+++ b/src/metadater/tei_parczech.xml
@@ -38,7 +38,7 @@
     <pcz:item pcz:dep="tagsDecl.ann" />
     <pcz:item pcz:dep="ParCzech-extent.ann" />
     <pcz:item pcz:dep="udpipe2" />
-    <pcz:item pcz:dep="udpipe2.app-czech-pdt-ud-2.6-200830" />
+    <pcz:item pcz:dep="udpipe2.app-czech-pdt-ud-2.10-220711" />
 
 
     <pcz:item pcz:dep="NER.conll2003" />
@@ -811,6 +811,20 @@
         <application ident="UDPipe" version="2">
           <label>UDPipe 2 (czech-pdt-ud-2.6-200830 model)</label>
           <desc>POS tagging, lemmatization and dependency parsing done with UDPipe 2 (<ref target="http://ufal.mff.cuni.cz/udpipe/2">http://ufal.mff.cuni.cz/udpipe/2</ref>) with czech-pdt-ud-2.6-200830 model</desc>
+        </application>
+      </pcz:tei>
+    </pcz:item>
+  </pcz:meta>
+
+  <pcz:meta pcz:name="udpipe2.app-czech-pdt-ud-2.10-220711">
+    <pcz:item pcz:xpath="/tei:*/tei:teiHeader/tei:encodingDesc/tei:appInfo">
+      <pcz:test>
+        <pcz:false pcz:xpath="/tei:*/tei:teiHeader/tei:encodingDesc/tei:appInfo/tei:application[@ident='UDPipe']" />
+      </pcz:test>
+      <pcz:tei>
+        <application ident="UDPipe" version="2">
+          <label>UDPipe 2 (czech-pdt-ud-2.10-220711 model)</label>
+          <desc>POS tagging, lemmatization and dependency parsing done with UDPipe 2 (<ref target="http://ufal.mff.cuni.cz/udpipe/2">http://ufal.mff.cuni.cz/udpipe/2</ref>) with czech-pdt-ud-2.10-220711 model</desc>
         </application>
       </pcz:tei>
     </pcz:item>

--- a/src/run_parczech.sh
+++ b/src/run_parczech.sh
@@ -446,7 +446,7 @@ mkdir -p $UDPIPE_TEI
 log "annotating udpipe2 $UDPIPE_TEI"
 
 perl -I lib udpipe2/udpipe2.pl --colon2underscore \
-                               --model=czech-pdt-ud-2.6-200830 \
+                               --model=czech-pdt-ud-2.10-220711 \
                                --filelist $TEI_FILELIST \
                                --input-dir $DOWNLOADER_TEI_META \
                                --output-dir $UDPIPE_TEI


### PR DESCRIPTION
fixing this `<pb>` element inside text:
```XML
<seg xml:id="NRSITZ_020_00040_d2e931">Bericht ... über die<pb n="30"/>Einhebung ...</seg>
```

with new parameter `--try2fix-spaces`

@hpreki can you allow issues in this repository? I have a few observations on your data - or do you develop it elsewhere where the issue can be created?
